### PR TITLE
Fix fisher command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ into fish configuration.
 Install with [Fisher][] (recommended):
 
 ```fish
-fisher install halostatue/fish-direnv@1.x
+fisher install halostatue/fish-direnv@v1.x
 ```
 
 <details>


### PR DESCRIPTION
Using `fisher install halostatue/fish-direnv@1.x` as suggested in the README, fisher returns this error:
`fisher: Invalid plugin name or host unavailable: "halostatue/fish-direnv@1.x"`

That's because the tags use the prefix "v". `fisher install halostatue/fish-direnv@v1.x` fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/fish-direnv/1)
<!-- Reviewable:end -->
