### PR TITLE
use `status is-interactive` since is-interactive no longer works

### DIFF
--- a/conf.d/halostatue_fish_direnv.fish
+++ b/conf.d/halostatue_fish_direnv.fish
@@ -1,6 +1,6 @@
 # @halostatue/fish-direnv/conf.d/halostatue_fish_direnv.fish
 
-if is-interactive && command -sq direnv && not functions -q __direnv_export_eval
+if status is-interactive && command -sq direnv && not functions -q __direnv_export_eval
     direnv hook fish | source
 end
 


### PR DESCRIPTION
Started failing for me recently after a recent brew update. Most docs now point to `status is-interactive`. Couldn't find a reference to `is-interactive` which was working for me before today.

Thanks for building the plugin. I understand you are no longer using direnv so feel free to merge this whenever possible. Hopefully this PR should help others if they do run into the same issue.

